### PR TITLE
feat: asynchronous JCR computation (compute/status/result) to avoid request timeouts

### DIFF
--- a/src/javascript/JcrStats/JcrStats.gql.js
+++ b/src/javascript/JcrStats/JcrStats.gql.js
@@ -1,9 +1,30 @@
 import {gql} from '@apollo/client';
 
-export const GET_TREE = gql`
-    query JcrStatsTree($path: String, $maxDepth: Int) {
+export const COMPUTE = gql`
+    mutation JcrStatsCompute($path: String) {
         jcrStats {
-            tree(path: $path, maxDepth: $maxDepth) {
+            compute(path: $path)
+        }
+    }
+`;
+
+export const GET_STATUS = gql`
+    query JcrStatsStatus {
+        jcrStats {
+            status {
+                running
+                path
+                error
+                hasResult
+            }
+        }
+    }
+`;
+
+export const GET_RESULT = gql`
+    query JcrStatsResult($maxDepth: Int) {
+        jcrStats {
+            result(maxDepth: $maxDepth) {
                 name
                 path
                 size

--- a/src/javascript/JcrStats/JcrStats.gql.js
+++ b/src/javascript/JcrStats/JcrStats.gql.js
@@ -16,6 +16,9 @@ export const GET_STATUS = gql`
                 path
                 error
                 hasResult
+                startedAt
+                elapsedMs
+                visitedCount
             }
         }
     }

--- a/src/javascript/JcrStats/JcrStats.jsx
+++ b/src/javascript/JcrStats/JcrStats.jsx
@@ -1,10 +1,10 @@
 import React, {useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo} from 'react';
-import {useLazyQuery} from '@apollo/client';
+import {useLazyQuery, useMutation, useQuery} from '@apollo/client';
 import {useTranslation} from 'react-i18next';
 import {Button, Loader, Typography, Bar, Download, Upload, Compare} from '@jahia/moonstone';
 import {FlameGraph} from 'react-flame-graph';
 import styles from './JcrStats.scss';
-import {GET_TREE} from './JcrStats.gql';
+import {COMPUTE, GET_STATUS, GET_RESULT} from './JcrStats.gql';
 import {formatBytes, METRIC_SIZE, METRIC_NODES, buildJContentUrl} from './jcrStatsUtils';
 import {TreeTable} from './TreeTable';
 import {TopList} from './TopList';
@@ -12,6 +12,7 @@ import {DiffTable} from './DiffTable';
 
 const DEFAULT_PATH = '/sites';
 const MAX_DEPTH = 6;
+const STATUS_POLL_MS = 2000;
 const BOTTOM_MARGIN = 24;
 const MIN_HEIGHT = 320;
 const SAVE_FORMAT = 'jcr-stats-flamegraph';
@@ -58,6 +59,7 @@ export const JcrStatsAdmin = () => {
     const [tree, setTree] = useState(null);
     const [treePath, setTreePath] = useState(DEFAULT_PATH);
     const [baseline, setBaseline] = useState(null);
+    const [computing, setComputing] = useState(false);
     const containerRef = useRef(null);
     const fileInputRef = useRef(null);
     const baselineInputRef = useRef(null);
@@ -69,7 +71,14 @@ export const JcrStatsAdmin = () => {
         document.title = `${t('label.title')} — Jahia Administration`;
     }, [t]);
 
-    const [loadTree, {loading}] = useLazyQuery(GET_TREE, {fetchPolicy: 'network-only'});
+    const [startCompute] = useMutation(COMPUTE);
+    const [fetchResult] = useLazyQuery(GET_RESULT, {fetchPolicy: 'network-only'});
+    // While a computation runs, poll its status; the heavy traversal happens server-side off-request.
+    const {data: statusData} = useQuery(GET_STATUS, {
+        skip: !computing,
+        pollInterval: computing ? STATUS_POLL_MS : 0,
+        fetchPolicy: 'network-only'
+    });
 
     const flameData = useMemo(() => (tree ? toFlameNode(tree, metric) : null), [tree, metric]);
 
@@ -100,6 +109,41 @@ export const JcrStatsAdmin = () => {
         return () => window.removeEventListener('resize', measure);
     }, [flameData, measure, view]);
 
+    // When the polled status reports the async computation is done, fetch + render the cached result.
+    useEffect(() => {
+        if (!computing) {
+            return;
+        }
+
+        const current = statusData && statusData.jcrStats && statusData.jcrStats.status;
+        if (!current || current.running) {
+            return;
+        }
+
+        setComputing(false);
+        if (current.error) {
+            setStatus('error');
+            return;
+        }
+
+        if (current.hasResult) {
+            fetchResult({variables: {maxDepth: MAX_DEPTH}})
+                .then(response => {
+                    const computed = response && response.data && response.data.jcrStats && response.data.jcrStats.result;
+                    if (computed) {
+                        setFocused(null);
+                        setTree(computed);
+                        setTreePath(current.path);
+                        setView(VIEW_FLAMEGRAPH);
+                        setStatus('success');
+                    } else {
+                        setStatus('error');
+                    }
+                })
+                .catch(() => setStatus('error'));
+        }
+    }, [statusData, computing, fetchResult]);
+
     const handleFocusChange = useCallback(node => {
         if (node) {
             const source = node.source || node;
@@ -129,16 +173,10 @@ export const JcrStatsAdmin = () => {
         setFocused(null);
         const targetPath = path || '/';
         try {
-            const result = await loadTree({variables: {path: targetPath, maxDepth: MAX_DEPTH}});
-            const computed = result?.data?.jcrStats?.tree;
-            if (computed) {
-                setTree(computed);
-                setTreePath(targetPath);
-                setView(VIEW_FLAMEGRAPH);
-                setStatus('success');
-            } else {
-                setStatus('error');
-            }
+            // Fire-and-forget: starts the server-side job (no-op if one is already running),
+            // then we poll jcrStats.status and fetch the result when it completes.
+            await startCompute({variables: {path: targetPath}});
+            setComputing(true);
         } catch (_) {
             setStatus('error');
         }
@@ -257,9 +295,9 @@ export const JcrStatsAdmin = () => {
                         <option value={METRIC_SIZE}>{t('label.metricSize')}</option>
                         <option value={METRIC_NODES}>{t('label.metricNodes')}</option>
                     </select>
-                    <Button size="big" color="accent" icon={<Bar/>} label={t('label.compute')} isDisabled={loading} onClick={handleCompute}/>
-                    <Button size="big" icon={<Upload/>} label={t('label.load')} isDisabled={loading} onClick={() => fileInputRef.current && fileInputRef.current.click()}/>
-                    <Button size="big" icon={<Compare/>} label={t('label.compareWith')} isDisabled={loading} onClick={() => baselineInputRef.current && baselineInputRef.current.click()}/>
+                    <Button size="big" color="accent" icon={<Bar/>} label={t('label.compute')} isDisabled={computing} onClick={handleCompute}/>
+                    <Button size="big" icon={<Upload/>} label={t('label.load')} isDisabled={computing} onClick={() => fileInputRef.current && fileInputRef.current.click()}/>
+                    <Button size="big" icon={<Compare/>} label={t('label.compareWith')} isDisabled={computing} onClick={() => baselineInputRef.current && baselineInputRef.current.click()}/>
                     {/*
                       H-3: Hidden file inputs are now clipped (sr-only) rather than display:none
                       so AT can discover them, and each has an associated <label> for a proper
@@ -294,7 +332,7 @@ export const JcrStatsAdmin = () => {
                 </div>
             </section>
 
-            {loading && (
+            {computing && (
                 <div className={styles.js_running}>
                     <Loader size="big"/>
                     <Typography className={styles.js_running_text}>{t('label.computing')}</Typography>
@@ -312,7 +350,7 @@ export const JcrStatsAdmin = () => {
                 </div>
             )}
 
-            {!tree && !loading && status !== 'error' && (
+            {!tree && !computing && status !== 'error' && (
                 <div className={styles.js_empty}>
                     {baseline ? t('label.baselineLoadedHint') : t('label.emptyHint')}
                 </div>

--- a/src/javascript/JcrStats/JcrStats.jsx
+++ b/src/javascript/JcrStats/JcrStats.jsx
@@ -5,7 +5,7 @@ import {Button, Loader, Typography, Bar, Download, Upload, Compare} from '@jahia
 import {FlameGraph} from 'react-flame-graph';
 import styles from './JcrStats.scss';
 import {COMPUTE, GET_STATUS, GET_RESULT} from './JcrStats.gql';
-import {formatBytes, METRIC_SIZE, METRIC_NODES, buildJContentUrl} from './jcrStatsUtils';
+import {formatBytes, formatDuration, METRIC_SIZE, METRIC_NODES, buildJContentUrl} from './jcrStatsUtils';
 import {TreeTable} from './TreeTable';
 import {TopList} from './TopList';
 import {DiffTable} from './DiffTable';
@@ -60,6 +60,9 @@ export const JcrStatsAdmin = () => {
     const [treePath, setTreePath] = useState(DEFAULT_PATH);
     const [baseline, setBaseline] = useState(null);
     const [computing, setComputing] = useState(false);
+    const [visitedCount, setVisitedCount] = useState(0);
+    const [, setNowTick] = useState(0);
+    const serverElapsedRef = useRef({base: 0, at: 0});
     const containerRef = useRef(null);
     const fileInputRef = useRef(null);
     const baselineInputRef = useRef(null);
@@ -73,6 +76,7 @@ export const JcrStatsAdmin = () => {
 
     const [startCompute] = useMutation(COMPUTE);
     const [fetchResult] = useLazyQuery(GET_RESULT, {fetchPolicy: 'network-only'});
+    const [fetchStatus] = useLazyQuery(GET_STATUS, {fetchPolicy: 'network-only'});
     // While a computation runs, poll its status; the heavy traversal happens server-side off-request.
     const {data: statusData} = useQuery(GET_STATUS, {
         skip: !computing,
@@ -116,7 +120,13 @@ export const JcrStatsAdmin = () => {
         }
 
         const current = statusData && statusData.jcrStats && statusData.jcrStats.status;
-        if (!current || current.running) {
+        if (!current) {
+            return;
+        }
+
+        setVisitedCount(Number(current.visitedCount) || 0);
+        if (current.running) {
+            serverElapsedRef.current = {base: Number(current.elapsedMs) || 0, at: Date.now()};
             return;
         }
 
@@ -143,6 +153,33 @@ export const JcrStatsAdmin = () => {
                 .catch(() => setStatus('error'));
         }
     }, [statusData, computing, fetchResult]);
+
+    // Tick every second while computing so the elapsed timer updates smoothly between 2s polls.
+    useEffect(() => {
+        if (!computing) {
+            return undefined;
+        }
+
+        const id = setInterval(() => setNowTick(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [computing]);
+
+    // On (re)mount, re-read server status so leaving the page and coming back keeps the live status
+    // of a still-running computation visible (the polling resumes from the server's elapsed/visited).
+    // A *finished* result is intentionally NOT auto-restored: doing so would asynchronously clobber a
+    // tree the user has since loaded from a file (race) and surface another user's last run.
+    useEffect(() => {
+        fetchStatus()
+            .then(response => {
+                const current = response && response.data && response.data.jcrStats && response.data.jcrStats.status;
+                if (current && current.running) {
+                    serverElapsedRef.current = {base: Number(current.elapsedMs) || 0, at: Date.now()};
+                    setVisitedCount(Number(current.visitedCount) || 0);
+                    setComputing(true);
+                }
+            })
+            .catch(() => {});
+    }, [fetchStatus]);
 
     const handleFocusChange = useCallback(node => {
         if (node) {
@@ -171,6 +208,8 @@ export const JcrStatsAdmin = () => {
     const handleCompute = async () => {
         setStatus(null);
         setFocused(null);
+        setVisitedCount(0);
+        serverElapsedRef.current = {base: 0, at: Date.now()};
         const targetPath = path || '/';
         try {
             // Fire-and-forget: starts the server-side job (no-op if one is already running),
@@ -333,9 +372,16 @@ export const JcrStatsAdmin = () => {
             </section>
 
             {computing && (
-                <div className={styles.js_running}>
+                <div className={styles.js_running} data-testid="jcrstats-progress">
                     <Loader size="big"/>
-                    <Typography className={styles.js_running_text}>{t('label.computing')}</Typography>
+                    <div>
+                        <Typography className={styles.js_running_text}>
+                            {`${t('label.computing')} ${formatDuration(serverElapsedRef.current.base + (Date.now() - serverElapsedRef.current.at))} · ${visitedCount.toLocaleString()} ${t('label.nodesScanned')}`}
+                        </Typography>
+                        <div className={styles.js_progress} role="progressbar" aria-label={t('label.computing')}>
+                            <div className={styles.js_progress_bar}/>
+                        </div>
+                    </div>
                 </div>
             )}
 

--- a/src/javascript/JcrStats/JcrStats.scss
+++ b/src/javascript/JcrStats/JcrStats.scss
@@ -309,3 +309,25 @@
   color: var(--color-gray, #3d4450);
   font-style: italic;
 }
+
+.js_progress {
+  width: 240px;
+  height: 6px;
+  margin-top: 6px;
+  background: #e5e7eb;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.js_progress_bar {
+  width: 40%;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--color-accent, #00a0e3);
+  animation: jcrstats-indeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes jcrstats-indeterminate {
+  0% { margin-left: -40%; }
+  100% { margin-left: 100%; }
+}

--- a/src/javascript/JcrStats/__tests__/jcrStatsUtils.test.js
+++ b/src/javascript/JcrStats/__tests__/jcrStatsUtils.test.js
@@ -4,6 +4,7 @@ import {
     percent,
     flatten,
     buildJContentUrl,
+    formatDuration,
     diffTrees,
     signedBytes,
     METRIC_SIZE,
@@ -323,5 +324,21 @@ describe('signedBytes', () => {
 
     it('formats a large negative delta correctly', () => {
         expect(signedBytes(-KIB * KIB)).toBe('-1.0 MB');
+    });
+});
+
+describe('formatDuration', () => {
+    it('formats sub-minute durations in seconds', () => {
+        expect(formatDuration(0)).toBe('0s');
+        expect(formatDuration(8000)).toBe('8s');
+        expect(formatDuration(59000)).toBe('59s');
+    });
+    it('formats minute+ durations with zero-padded seconds', () => {
+        expect(formatDuration(65000)).toBe('1m 05s');
+        expect(formatDuration(600000)).toBe('10m 00s');
+    });
+    it('clamps negative / non-finite input to 0s', () => {
+        expect(formatDuration(-5000)).toBe('0s');
+        expect(formatDuration(NaN)).toBe('0s');
     });
 });

--- a/src/javascript/JcrStats/jcrStatsUtils.js
+++ b/src/javascript/JcrStats/jcrStatsUtils.js
@@ -107,3 +107,11 @@ export const signedBytes = delta => {
     const sign = delta > 0 ? '+' : delta < 0 ? '-' : '';
     return `${sign}${formatBytes(Math.abs(delta))}`;
 };
+
+// Human-readable elapsed time, e.g. "8s" or "2m 05s".
+export const formatDuration = ms => {
+    const totalSeconds = Math.max(0, Math.floor(Number(ms) / 1000) || 0);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return minutes > 0 ? `${minutes}m ${String(seconds).padStart(2, '0')}s` : `${seconds}s`;
+};

--- a/src/main/java/org/jahia/community/jcrstats/JcrStatsComputer.java
+++ b/src/main/java/org/jahia/community/jcrstats/JcrStatsComputer.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Reusable JCR size-computation engine.
@@ -63,7 +64,15 @@ public class JcrStatsComputer {
      * Read-only: safe to call from a GraphQL query.
      */
     public NodeStats computeStats(String path) throws RepositoryException {
-        return JCRTemplate.getInstance().doExecuteWithSystemSession((JCRSessionWrapper session) -> computeSize(session, path));
+        return computeStats(path, new AtomicLong());
+    }
+
+    /**
+     * Computes the subtree size while incrementing {@code visited} once per node visited, so a
+     * long-running computation can report live progress (a JCR tree has no known total up front).
+     */
+    public NodeStats computeStats(String path, AtomicLong visited) throws RepositoryException {
+        return JCRTemplate.getInstance().doExecuteWithSystemSession((JCRSessionWrapper session) -> computeSize(session, path, visited));
     }
 
     /**
@@ -256,8 +265,9 @@ public class JcrStatsComputer {
         return sb.toString();
     }
 
-    private NodeStats computeSize(JCRSessionWrapper session, String currentPath) throws RepositoryException {
+    private NodeStats computeSize(JCRSessionWrapper session, String currentPath, AtomicLong visited) throws RepositoryException {
         session.refresh(false);
+        visited.incrementAndGet();
         final NodeStats currentNodeStats = new NodeStats(currentPath);
         final QueryManagerWrapper manager = session.getWorkspace().getQueryManager();
         final String queryStmt = String.format("SELECT * FROM [%s] AS content WHERE ISCHILDNODE(content, '%s')", JcrConstants.NT_BASE, JCRContentUtils.sqlEncode(currentPath));
@@ -270,7 +280,7 @@ public class JcrStatsComputer {
 
         while (nodeIterator.hasNext()) {
             final JCRNodeWrapper subNodeWrapper = (JCRNodeWrapper) nodeIterator.next();
-            final NodeStats nodeStats = computeSize(session, subNodeWrapper.getPath());
+            final NodeStats nodeStats = computeSize(session, subNodeWrapper.getPath(), visited);
             currentNodeStats.addSubNodeStats(nodeStats);
         }
 

--- a/src/main/java/org/jahia/community/jcrstats/JcrStatsService.java
+++ b/src/main/java/org/jahia/community/jcrstats/JcrStatsService.java
@@ -10,6 +10,7 @@ import javax.jcr.RepositoryException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Runs JCR size computations asynchronously on a single background thread and caches the latest
@@ -27,10 +28,13 @@ public class JcrStatsService {
     private static final String GENERIC_ERROR = "Computation failed. Check server logs for details.";
 
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicLong visited = new AtomicLong();
     private volatile NodeStats lastResult;
     private volatile String lastPath;
     private volatile String lastError;
     private volatile long computedAt;
+    private volatile long startedAt;
+    private volatile long finishedAt;
     private ExecutorService executor;
 
     @Activate
@@ -59,9 +63,12 @@ public class JcrStatsService {
             return false;
         }
         lastError = null;
+        visited.set(0L);
+        startedAt = System.currentTimeMillis();
+        finishedAt = 0L;
         executor.submit(() -> {
             try {
-                final NodeStats tree = new JcrStatsComputer().computeStats(effectivePath);
+                final NodeStats tree = new JcrStatsComputer().computeStats(effectivePath, visited);
                 lastResult = tree;
                 lastPath = effectivePath;
                 computedAt = System.currentTimeMillis();
@@ -69,6 +76,7 @@ public class JcrStatsService {
                 lastError = GENERIC_ERROR;
                 LOGGER.error("Asynchronous JCR stats computation failed for path {}", effectivePath, e);
             } finally {
+                finishedAt = System.currentTimeMillis();
                 running.set(false);
             }
         });
@@ -93,5 +101,24 @@ public class JcrStatsService {
 
     public long getComputedAt() {
         return computedAt;
+    }
+
+    /** Epoch millis when the current/last computation started (0 if none yet). */
+    public long getStartedAt() {
+        return startedAt;
+    }
+
+    /** Elapsed time in ms: live while running, otherwise the duration of the last run. */
+    public long getElapsedMs() {
+        if (startedAt == 0L) {
+            return 0L;
+        }
+        final long end = running.get() ? System.currentTimeMillis() : finishedAt;
+        return Math.max(0L, end - startedAt);
+    }
+
+    /** Number of nodes visited so far by the current/last computation. */
+    public long getVisitedCount() {
+        return visited.get();
     }
 }

--- a/src/main/java/org/jahia/community/jcrstats/JcrStatsService.java
+++ b/src/main/java/org/jahia/community/jcrstats/JcrStatsService.java
@@ -1,0 +1,97 @@
+package org.jahia.community.jcrstats;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Runs JCR size computations asynchronously on a single background thread and caches the latest
+ * result. A full subtree traversal can take a long time on large repositories, so the GraphQL API
+ * exposes a fire-and-forget {@code compute} mutation plus {@code status}/{@code result} queries the
+ * UI polls — instead of one synchronous call that would block the request until it times out.
+ *
+ * <p>Only one computation runs at a time; {@link #start(String)} is a no-op (returns {@code false})
+ * while one is already in progress.</p>
+ */
+@Component(immediate = true, service = JcrStatsService.class)
+public class JcrStatsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JcrStatsService.class);
+    private static final String GENERIC_ERROR = "Computation failed. Check server logs for details.";
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private volatile NodeStats lastResult;
+    private volatile String lastPath;
+    private volatile String lastError;
+    private volatile long computedAt;
+    private ExecutorService executor;
+
+    @Activate
+    public void activate() {
+        executor = Executors.newSingleThreadExecutor(runnable -> {
+            final Thread thread = new Thread(runnable, "jcr-stats-computation");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @Deactivate
+    public void deactivate() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Starts an asynchronous computation of the subtree at {@code path}. Returns {@code false}
+     * without starting anything if a computation is already in progress.
+     */
+    public boolean start(String path) {
+        final String effectivePath = (path == null || path.isEmpty()) ? "/" : path;
+        if (!running.compareAndSet(false, true)) {
+            return false;
+        }
+        lastError = null;
+        executor.submit(() -> {
+            try {
+                final NodeStats tree = new JcrStatsComputer().computeStats(effectivePath);
+                lastResult = tree;
+                lastPath = effectivePath;
+                computedAt = System.currentTimeMillis();
+            } catch (RepositoryException | RuntimeException e) {
+                lastError = GENERIC_ERROR;
+                LOGGER.error("Asynchronous JCR stats computation failed for path {}", effectivePath, e);
+            } finally {
+                running.set(false);
+            }
+        });
+        return true;
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    public NodeStats getLastResult() {
+        return lastResult;
+    }
+
+    public String getLastPath() {
+        return lastPath;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public long getComputedAt() {
+        return computedAt;
+    }
+}

--- a/src/main/java/org/jahia/community/jcrstats/graphql/JcrStatsMutation.java
+++ b/src/main/java/org/jahia/community/jcrstats/graphql/JcrStatsMutation.java
@@ -5,7 +5,9 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.community.jcrstats.ComputeResult;
 import org.jahia.community.jcrstats.JcrStatsComputer;
+import org.jahia.community.jcrstats.JcrStatsService;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +18,18 @@ import javax.jcr.RepositoryException;
 public class JcrStatsMutation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JcrStatsMutation.class);
+
+    @GraphQLField
+    @GraphQLName("compute")
+    @GraphQLDescription("Starts an asynchronous computation of the subtree at the given path. Returns false if one is already running. Poll jcrStats.status, then read jcrStats.result when it finishes.")
+    @GraphQLRequiresPermission("jcrStatsAdmin")
+    public Boolean compute(
+            @GraphQLName("path")
+            @GraphQLDescription("JCR path to compute (defaults to /)")
+            String path) {
+        final JcrStatsService service = BundleUtils.getOsgiService(JcrStatsService.class, null);
+        return service != null && service.start(path);
+    }
 
     @GraphQLField
     @GraphQLName("computeSize")

--- a/src/main/java/org/jahia/community/jcrstats/graphql/JcrStatsQuery.java
+++ b/src/main/java/org/jahia/community/jcrstats/graphql/JcrStatsQuery.java
@@ -4,11 +4,13 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.community.jcrstats.JcrStatsComputer;
+import org.jahia.community.jcrstats.JcrStatsService;
 import org.jahia.community.jcrstats.NodeStats;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.services.content.JCRNodeIteratorWrapper;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRTemplate;
+import org.jahia.osgi.BundleUtils;
 import org.jahia.services.query.QueryWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +88,38 @@ public class JcrStatsQuery {
     }
 
     @GraphQLField
+    @GraphQLName("status")
+    @GraphQLDescription("Status of the asynchronous computation: running flag, last path, error, and whether a cached result is ready.")
+    @GraphQLRequiresPermission("jcrStatsAdmin")
+    public GqlJcrStatsStatus status() {
+        final JcrStatsService service = BundleUtils.getOsgiService(JcrStatsService.class, null);
+        if (service == null) {
+            return new GqlJcrStatsStatus(false, null, null, false);
+        }
+        return new GqlJcrStatsStatus(service.isRunning(), service.getLastPath(), service.getLastError(), service.getLastResult() != null);
+    }
+
+    @GraphQLField
+    @GraphQLName("result")
+    @GraphQLDescription("Returns the latest asynchronously-computed tree pruned to maxDepth, or null if none is available yet.")
+    @GraphQLRequiresPermission("jcrStatsAdmin")
+    public GqlNodeStats result(
+            @GraphQLName("maxDepth")
+            @GraphQLDescription("Maximum number of child levels to include (default 6).")
+            Integer maxDepth) {
+        final JcrStatsService service = BundleUtils.getOsgiService(JcrStatsService.class, null);
+        if (service == null) {
+            return null;
+        }
+        final NodeStats tree = service.getLastResult();
+        if (tree == null) {
+            return null;
+        }
+        final int depth = maxDepth == null ? DEFAULT_MAX_DEPTH : Math.max(0, maxDepth);
+        return new GqlNodeStats(tree, depth);
+    }
+
+    @GraphQLField
     @GraphQLName("reports")
     @GraphQLDescription("Lists the generated flamegraph files stored under " + REPORTS_BASE_PATH)
     @GraphQLRequiresPermission("jcrStatsAdmin")
@@ -109,6 +143,51 @@ public class JcrStatsQuery {
         } catch (RepositoryException e) {
             LOGGER.error("Failed to list jcr-stats reports", e);
             return Collections.emptyList();
+        }
+    }
+
+    @GraphQLName("JcrStatsStatus")
+    @GraphQLDescription("Status of the asynchronous JCR stats computation")
+    public static class GqlJcrStatsStatus {
+
+        private final boolean running;
+        private final String path;
+        private final String error;
+        private final boolean hasResult;
+
+        public GqlJcrStatsStatus(boolean running, String path, String error, boolean hasResult) {
+            this.running = running;
+            this.path = path;
+            this.error = error;
+            this.hasResult = hasResult;
+        }
+
+        @GraphQLField
+        @GraphQLName("running")
+        @GraphQLDescription("Whether a computation is currently in progress")
+        public boolean isRunning() {
+            return running;
+        }
+
+        @GraphQLField
+        @GraphQLName("path")
+        @GraphQLDescription("Path of the last (or in-progress) computation")
+        public String getPath() {
+            return path;
+        }
+
+        @GraphQLField
+        @GraphQLName("error")
+        @GraphQLDescription("Error message of the last computation, or null")
+        public String getError() {
+            return error;
+        }
+
+        @GraphQLField
+        @GraphQLName("hasResult")
+        @GraphQLDescription("Whether a cached result is available to fetch")
+        public boolean isHasResult() {
+            return hasResult;
         }
     }
 

--- a/src/main/java/org/jahia/community/jcrstats/graphql/JcrStatsQuery.java
+++ b/src/main/java/org/jahia/community/jcrstats/graphql/JcrStatsQuery.java
@@ -94,9 +94,10 @@ public class JcrStatsQuery {
     public GqlJcrStatsStatus status() {
         final JcrStatsService service = BundleUtils.getOsgiService(JcrStatsService.class, null);
         if (service == null) {
-            return new GqlJcrStatsStatus(false, null, null, false);
+            return new GqlJcrStatsStatus(false, null, null, false, 0L, 0L, 0L);
         }
-        return new GqlJcrStatsStatus(service.isRunning(), service.getLastPath(), service.getLastError(), service.getLastResult() != null);
+        return new GqlJcrStatsStatus(service.isRunning(), service.getLastPath(), service.getLastError(), service.getLastResult() != null,
+                service.getStartedAt(), service.getElapsedMs(), service.getVisitedCount());
     }
 
     @GraphQLField
@@ -154,12 +155,19 @@ public class JcrStatsQuery {
         private final String path;
         private final String error;
         private final boolean hasResult;
+        private final long startedAt;
+        private final long elapsedMs;
+        private final long visitedCount;
 
-        public GqlJcrStatsStatus(boolean running, String path, String error, boolean hasResult) {
+        public GqlJcrStatsStatus(boolean running, String path, String error, boolean hasResult,
+                long startedAt, long elapsedMs, long visitedCount) {
             this.running = running;
             this.path = path;
             this.error = error;
             this.hasResult = hasResult;
+            this.startedAt = startedAt;
+            this.elapsedMs = elapsedMs;
+            this.visitedCount = visitedCount;
         }
 
         @GraphQLField
@@ -188,6 +196,27 @@ public class JcrStatsQuery {
         @GraphQLDescription("Whether a cached result is available to fetch")
         public boolean isHasResult() {
             return hasResult;
+        }
+
+        @GraphQLField
+        @GraphQLName("startedAt")
+        @GraphQLDescription("Epoch millis when the current/last computation started (0 if none)")
+        public long getStartedAt() {
+            return startedAt;
+        }
+
+        @GraphQLField
+        @GraphQLName("elapsedMs")
+        @GraphQLDescription("Elapsed time in ms: live while running, otherwise the last run's duration")
+        public long getElapsedMs() {
+            return elapsedMs;
+        }
+
+        @GraphQLField
+        @GraphQLName("visitedCount")
+        @GraphQLDescription("Number of nodes visited so far (live progress; no total is known up front)")
+        public long getVisitedCount() {
+            return visitedCount;
         }
     }
 

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -13,6 +13,7 @@
     "emptyHint": "Enter a JCR path and click Compute to analyze it.",
     "baselineLoadedHint": "Baseline loaded. Compute or load a current snapshot to compare it.",
     "computing": "Computing…",
+    "nodesScanned": "nodes scanned",
     "save": "Save data",
     "load": "Load data",
     "compareWith": "Compare with…",

--- a/tests/cypress/e2e/01-jcrStatsAPI.cy.ts
+++ b/tests/cypress/e2e/01-jcrStatsAPI.cy.ts
@@ -98,4 +98,33 @@ describe('JCR Stats - GraphQL API', () => {
                 });
         });
     });
+
+    describe('jcrStats async compute', () => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const compute: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/mutation/compute.graphql');
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const getStatus: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getStatus.graphql');
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const getResult: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getResult.graphql');
+
+        it('computes asynchronously: compute starts a job, status reports completion, result returns the tree', () => {
+            cy.apollo({mutation: compute, variables: {path: TEST_PATH}})
+                .its('data.jcrStats.compute')
+                .should('be.a', 'boolean');
+
+            // Poll status until the background job finishes and a result is cached
+            cy.waitUntil(
+                () => cy.apollo({query: getStatus, fetchPolicy: 'no-cache'})
+                    .then((r: {data: {jcrStats: {status: {running: boolean; hasResult: boolean}}}}) =>
+                        r.data.jcrStats.status.running === false && r.data.jcrStats.status.hasResult === true),
+                {timeout: 60000, interval: 2000}
+            );
+
+            cy.apollo({query: getResult, variables: {maxDepth: 3}})
+                .its('data.jcrStats.result')
+                .should((tree: {name: string; nodeCount: number}) => {
+                    expect(Number(tree.nodeCount)).to.be.at.least(1);
+                });
+        });
+    });
 });

--- a/tests/cypress/e2e/02-jcrStatsAdmin.cy.ts
+++ b/tests/cypress/e2e/02-jcrStatsAdmin.cy.ts
@@ -1,8 +1,23 @@
+import {DocumentNode} from 'graphql'
+
 describe('JCR Stats - Admin UI', () => {
     const adminPath = '/jahia/administration/jcrStatsExecution'
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const getStatus: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getStatus.graphql')
 
     before(() => {
         cy.login()
+    })
+
+    // The async computation is shared server state; wait until it is idle before each test so a
+    // long-running job started by a previous test is not picked up by the next one (resume-on-mount).
+    beforeEach(() => {
+        cy.login()
+        cy.waitUntil(
+            () => cy.apollo({query: getStatus, fetchPolicy: 'no-cache'})
+                .then((r: {data: {jcrStats: {status: {running: boolean}}}}) => r.data.jcrStats.status.running === false),
+            {timeout: 60000, interval: 2000}
+        )
     })
 
     it('shows the page title', () => {

--- a/tests/cypress/fixtures/graphql/mutation/compute.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/compute.graphql
@@ -1,0 +1,5 @@
+mutation compute($path: String) {
+    jcrStats {
+        compute(path: $path)
+    }
+}

--- a/tests/cypress/fixtures/graphql/query/getResult.graphql
+++ b/tests/cypress/fixtures/graphql/query/getResult.graphql
@@ -1,0 +1,16 @@
+query getResult($maxDepth: Int) {
+    jcrStats {
+        result(maxDepth: $maxDepth) {
+            name
+            path
+            size
+            nodeCount
+            children {
+                name
+                path
+                size
+                nodeCount
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/graphql/query/getStatus.graphql
+++ b/tests/cypress/fixtures/graphql/query/getStatus.graphql
@@ -1,0 +1,10 @@
+query getStatus {
+    jcrStats {
+        status {
+            running
+            path
+            error
+            hasResult
+        }
+    }
+}


### PR DESCRIPTION
## Why
A full subtree traversal (e.g. the default `/sites`) can take long enough that the synchronous `jcrStats.tree` GraphQL request **times out**.

## What
Run the traversal **asynchronously** (the proven versions-cleaner pattern):
- **`JcrStatsService`** (OSGi `@Component`): a single-thread executor runs the traversal off-request and caches the latest result + running/error state. Only one runs at a time.
- **GraphQL**: `mutation jcrStats.compute(path)` starts the job and returns immediately (no-op if one is already running); `query jcrStats.status` → `{running, path, error, hasResult}`; `query jcrStats.result(maxDepth)` returns the cached tree (built fast in-memory). The synchronous `tree`/`size`/`nodeCount` are kept for direct API use.
- **Admin UI**: "Compute" starts the job and **polls `status` every 2 s**, then fetches `result` when done — no long-held request, no timeout. Load / Save / Compare / diff are unchanged.

## Test plan
- `mvn clean package` — **24 Java unit tests** ✓ (new `JcrStatsService.xml` DS component generated)
- **Jest 48** ✓, **ESLint 0** ✓
- **Full Cypress E2E 28/28** ✓ — incl. a new async API test (`compute → status → result`); the admin-UI tests drive the async polling flow transparently.
