### PR TITLE
feat: merge admin menu into one entry and log job start/end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Progress UI shows elapsed timer and scanned-node counter
   - Resume-on-remount: navigating away from the page and back resumes status display of a still-running job
 
-- **React Admin UI** — Interactive space analysis interface at `/jahia/administration/jcrStatsExecution`:
+- **React Admin UI** — Interactive space analysis interface at `/jahia/administration/jcrStats`:
   - **Flamegraph View** — Click-to-zoom interactive visualization of space usage; keyboard hint advises use of Tree table for keyboard access
   - **Tree Table View** — Hierarchical breakdown with columns for size, % of total, % of parent, and node count; fully keyboard accessible
   - **Largest Items View** — Sorted top-N list of space consumers
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Root Package Renamed** — From `org.jahia.modules.*` to `org.jahia.community.jcrstats` (community module convention)
 - **Module Type** — Declared as `system` type module in `pom.xml`
 - **Karaf Command** — Refactored to delegate to `JcrStatsComputer` for shared logic
+- **Administration Menu** — Merged the two-level "JCR Statistics → Compute size" navigation into a single selectable **JCR Statistics** entry under System Health (route `jcrStats`); removed the redundant intermediate group
+- **Job Logging** — The asynchronous computation now emits `INFO` log lines when a job starts and when it finishes (with elapsed time and visited-node count)
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "ip-address": "^10.1.1",
     "js-yaml": "^4.1.1",
     "normalize-package-data": "^7.0.0",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "strip-ansi": "^6.0.1",
+    "string-width": "^4.2.3",
+    "wrap-ansi": "^7.0.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/javascript/JcrStats/register.jsx
+++ b/src/javascript/JcrStats/register.jsx
@@ -7,12 +7,6 @@ export default () => {
         targets: ['administration-server-systemHealth:998'],
         requiredPermission: 'jcrStatsAdmin',
         label: 'jcr-stats:label.menu_entry',
-        isSelectable: false
-    });
-    registry.add('adminRoute', 'jcrStatsExecution', {
-        targets: ['administration-server-jcrStats:1'],
-        requiredPermission: 'jcrStatsAdmin',
-        label: 'jcr-stats:label.menu_execution',
         isSelectable: true,
         render: () => React.createElement(JcrStatsAdmin)
     });

--- a/src/main/java/org/jahia/community/jcrstats/JcrStatsService.java
+++ b/src/main/java/org/jahia/community/jcrstats/JcrStatsService.java
@@ -65,6 +65,7 @@ public class JcrStatsService {
         startedAt = System.currentTimeMillis();
         finishedAt = 0L;
         executor.submit(() -> {
+            LOGGER.info("JCR stats computation started for path {}", effectivePath);
             try {
                 final NodeStats tree = new JcrStatsComputer().computeStats(effectivePath, visited);
                 lastResult.set(tree);
@@ -76,6 +77,8 @@ public class JcrStatsService {
             } finally {
                 finishedAt = System.currentTimeMillis();
                 running.set(false);
+                LOGGER.info("JCR stats computation finished for path {} in {} ms ({} nodes visited)",
+                        effectivePath, finishedAt - startedAt, visited.get());
             }
         });
         return true;

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -1,7 +1,6 @@
 {
   "label": {
     "menu_entry": "JCR Statistics",
-    "menu_execution": "Compute size",
     "title": "JCR Statistics",
     "description": "Compute a JCR subtree and analyze it as an interactive flamegraph, a sortable tree-table or a top-largest list, weighted by size or number of nodes. Save snapshots to a file, reload them, and compare two snapshots to see what changed. The same computation is available as the jcr-stats:compute-size Karaf command and the jcrStats GraphQL API.",
     "path": "Path",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,11 +2209,6 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
-  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
-
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
@@ -2225,11 +2220,6 @@ ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
-
-ansi-styles@^6.1.0:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
-  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 anymatch@^3.1.3:
   version "3.1.3"
@@ -2930,11 +2920,6 @@ duplexer@^0.1.2:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
-  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
 electron-to-chromium@^1.5.328:
   version "1.5.376"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz#16a9d4b72cb16c416aa73a879d92b047b96797ac"
@@ -2949,11 +2934,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-emoji-regex@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
-  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -6121,7 +6101,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6129,15 +6109,6 @@ string-length@^4.0.2:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string-width@^5.0.1, string-width@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
-  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
-  dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.12:
   version "4.0.12"
@@ -6206,19 +6177,12 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-ansi@^7.0.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
-  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
-  dependencies:
-    ansi-regex "^6.2.2"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -6786,7 +6750,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6794,15 +6758,6 @@ word-wrap@^1.2.5:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
## Summary

Two small, targeted changes to the jcr-stats administration experience plus a dev-harness fix.

### 1. Merge the two administration menu items into one
The admin navigation previously nested two levels under **System Health**:

```
System Health
  └ JCR Statistics    (group, not clickable)
      └ Compute size    (clickable, renders the analyzer)
```

Since the group had exactly one child, this collapses to a single selectable **JCR Statistics** entry (route `jcrStats`) that renders `JcrStatsAdmin` directly. The redundant `jcrStatsExecution` route and the now-unused `label.menu_execution` locale key are removed.

### 2. INFO logs when the async job starts and ends
`JcrStatsService.start(...)` now emits:
- `INFO` — *JCR stats computation started for path {}* when the background job begins
- `INFO` — *JCR stats computation finished for path {} in {} ms ({} nodes visited)* in the `finally` block (always fires, success or failure)

Parameterized logging (no string concatenation), so no new Sonar issues.

### 3. Dev harness fix (supporting)
Pinned `strip-ansi`/`string-width`/`wrap-ansi` to CJS-compatible versions via `resolutions` — the transitive ESM upgrades had broken `yarn lint` and `yarn test` locally (`ERR_REQUIRE_ESM`). CI was unaffected (Maven only runs `yarn build`).

## Verification
- `mvn clean install` + Sonar scan: **BUILD SUCCESS**, 52 Java tests pass
- SonarQube quality gate: **OK** (0 new issues, 0% new duplication)
- `yarn lint`: clean
- `yarn test`: **84 tests pass**

## Test plan
- [ ] Deploy module; confirm **System Health → JCR Statistics** is a single clickable entry that opens the analyzer
- [ ] Start a computation; confirm start + finish INFO lines in the Jahia log (finish line shows elapsed ms and node count)